### PR TITLE
Support a :use_ipv6 option to Resolv#initialize

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -82,8 +82,8 @@ class Resolv
   ##
   # Creates a new Resolv using +resolvers+.
 
-  def initialize(resolvers=[Hosts.new, DNS.new])
-    @resolvers = resolvers
+  def initialize(resolvers=nil, use_ipv6: nil)
+    @resolvers = resolvers || [Hosts.new, DNS.new(DNS::Config.default_config_hash.merge(use_ipv6: use_ipv6))]
   end
 
   ##
@@ -406,6 +406,11 @@ class Resolv
     end
 
     def use_ipv6? # :nodoc:
+      use_ipv6 = @config.use_ipv6?
+      unless use_ipv6.nil?
+        return use_ipv6
+      end
+
       begin
         list = Socket.ip_address_list
       rescue NotImplementedError
@@ -1004,6 +1009,7 @@ class Resolv
         @mutex.synchronize {
           unless @initialized
             @nameserver_port = []
+            @use_ipv6 = nil
             @search = nil
             @ndots = 1
             case @config_info
@@ -1027,6 +1033,9 @@ class Resolv
             end
             if config_hash.include? :nameserver_port
               @nameserver_port = config_hash[:nameserver_port].map {|ns, port| [ns, (port || Port)] }
+            end
+            if config_hash.include? :use_ipv6
+              @use_ipv6 = config_hash[:use_ipv6]
             end
             @search = config_hash[:search] if config_hash.include? :search
             @ndots = config_hash[:ndots] if config_hash.include? :ndots
@@ -1081,6 +1090,10 @@ class Resolv
 
       def nameserver_port
         @nameserver_port
+      end
+
+      def use_ipv6?
+        @use_ipv6
       end
 
       def generate_candidates(name)


### PR DESCRIPTION
When set, supports returning IPv6 results even if there is no
public IPv6 address for the system.