### PR TITLE
Revert the change to fix duplicate responses on Linux

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -705,8 +705,17 @@ class Resolv
         return msg, s.data
       end
 
-      def sender_for(addr, msg)
-        @senders.delete([addr,msg.id])
+      if /linux/ =~ RUBY_PLATFORM
+        # Workaround for Ruby Bug 17748, where on Linux requests
+        # for invalid domains wait for the socket to timeout if
+        # the address is deleted from @senders.
+        def sender_for(addr, msg)
+          @senders[[addr,msg.id]]
+        end
+      else
+        def sender_for(addr, msg)
+          @senders.delete([addr,msg.id])
+        end
       end
 
       def close

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -43,7 +43,7 @@ class TestResolvDNS < Test::Unit::TestCase
     begin
       OpenSSL
     rescue LoadError
-      skip 'autoload problem. see [ruby-dev:45021][Bug #5786]'
+      omit 'autoload problem. see [ruby-dev:45021][Bug #5786]'
     end if defined?(OpenSSL)
 
     with_udp('127.0.0.1', 0) {|u|
@@ -130,13 +130,13 @@ class TestResolvDNS < Test::Unit::TestCase
 
   def test_query_ipv4_duplicate_responses
     if /linux/ =~ RUBY_PLATFORM
-      skip 'Skipping duplicate response test on Linux, see [ruby-core:103013][Bug #17748]'
+      omit 'Skipping duplicate response test on Linux, see [ruby-core:103013][Bug #17748]'
     end
 
     begin
       OpenSSL
     rescue LoadError
-      skip 'autoload problem. see [ruby-dev:45021][Bug #5786]'
+      omit 'autoload problem. see [ruby-dev:45021][Bug #5786]'
     end if defined?(OpenSSL)
 
     with_udp('127.0.0.1', 0) {|u|
@@ -288,7 +288,7 @@ class TestResolvDNS < Test::Unit::TestCase
     rescue Timeout::Error
       if RUBY_PLATFORM.match?(/mingw/)
         # cannot repo locally
-        skip 'Timeout Error on MinGW CI'
+        omit 'Timeout Error on MinGW CI'
       else
         raise Timeout::Error
       end

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -129,6 +129,10 @@ class TestResolvDNS < Test::Unit::TestCase
   end
 
   def test_query_ipv4_duplicate_responses
+    if /linux/ =~ RUBY_PLATFORM
+      skip 'Skipping duplicate response test on Linux, see [ruby-core:103013][Bug #17748]'
+    end
+
     begin
       OpenSSL
     rescue LoadError


### PR DESCRIPTION
Linux seems to have a bug where resolving an invalid domain hangs
until the socket times out.  This doesn't appear to affect other
operating systems.  The timeouts for invalid domains are definitely
worse than improper handling of duplicate responses, so revert the
code on Linux but keep it on other operating systems that do not
have the timeout issue.