### PR TITLE
Support a :raise_timeout_errors option to raise timeouts as Resolv::ResolvError

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -310,6 +310,8 @@ class Resolv
     # String:: Path to a file using /etc/resolv.conf's format.
     # Hash:: Must contain :nameserver, :search and :ndots keys.
     # :nameserver_port can be used to specify port number of nameserver address.
+    # :raise_timeout_errors can be used to raise timeout errors
+    # as exceptions instead of treating the same as an NXDOMAIN response.
     #
     # The value of :nameserver should be an address string or
     # an array of address strings.
@@ -1030,6 +1032,7 @@ class Resolv
             end
             @search = config_hash[:search] if config_hash.include? :search
             @ndots = config_hash[:ndots] if config_hash.include? :ndots
+            @raise_timeout_errors = config_hash[:raise_timeout_errors]
 
             if @nameserver_port.empty?
               @nameserver_port << ['0.0.0.0', Port]
@@ -1116,6 +1119,7 @@ class Resolv
       def resolv(name)
         candidates = generate_candidates(name)
         timeouts = @timeouts || generate_timeouts
+        timeout_error = false
         begin
           candidates.each {|candidate|
             begin
@@ -1127,11 +1131,13 @@ class Resolv
                   end
                 }
               }
+              timeout_error = true
               raise ResolvError.new("DNS resolv timeout: #{name}")
             rescue NXDomain
             end
           }
         rescue ResolvError
+          raise if @raise_timeout_errors && timeout_error
         end
       end
 

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -457,4 +457,28 @@ class TestResolvDNS < Test::Unit::TestCase
     end
     assert_raise(Resolv::ResolvError) { dns.each_name('example.com') }
   end
+
+  def test_unreachable_server
+    unreachable_ip = '127.0.0.1'
+    sock = UDPSocket.new
+    sock.connect(unreachable_ip, 53)
+    begin
+      sock.send('1', 0)
+    rescue Errno::ENETUNREACH, Errno::EHOSTUNREACH
+    else
+      omit('cannot test unreachable server, as IP used is reachable')
+    end
+
+    config = {
+      :nameserver => [unreachable_ip],
+      :search => ['lan'],
+      :ndots => 1
+    }
+    r = Resolv.new([Resolv::DNS.new(config)])
+    assert_equal([], r.getaddresses('www.google.com'))
+
+    config[:raise_timeout_errors] = true
+    r = Resolv.new([Resolv::DNS.new(config)])
+    assert_raise(Resolv::ResolvError) { r.getaddresses('www.google.com') }
+  end
 end


### PR DESCRIPTION
This allows to differentiate a timeout from an NXDOMAIN response.

Fixes [Bug #18151]