### PR TITLE
macos: support multiple system resolvers like C

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -342,6 +342,23 @@ class TestResolvDNS < Test::Unit::TestCase
     end
   end
 
+  def test_macos_resolver_port
+    return unless /darwin/ =~ RUBY_PLATFORM
+
+    Tempfile.create('resolv_test_macos_resolver_port_') do |tmpfile|
+      tmpfile.puts "domain localdomain"
+      tmpfile.puts "nameserver 127.0.0.1"
+      tmpfile.puts "port 55353"
+      tmpfile.close
+      config_hash = Resolv::DNS::Config.parse_resolv_conf(tmpfile.path)
+      assert_equal({
+        :nameserver_port => [['127.0.0.1', 55353]],
+        :search => ['localdomain'],
+        :ndots => 1,
+      }, config_hash)
+    end
+  end
+
   def test_dots_diffences
     name1 = Resolv::DNS::Name.create("example.org")
     name2 = Resolv::DNS::Name.create("ex.ampl.eo.rg")


### PR DESCRIPTION
On macOS, `libresolv` supports multiple resolvers. This allows users, VPN clients, etc. to delegate queries for certain domains to other resolvers, in addition to the "Super Resolver" specified by `/etc/resolv.conf`. An example of this would be using something like `dnsmasq` or `launchdns` to resolve a [Special Use Domain (described by RFC 6761)](https://datatracker.ietf.org/doc/html/rfc6761) for local development like `*.localhost` or `*.test`

This is supported transparently via the `gethostbyname` and `getaddrinfo` C calls, but when replacing use of those APIs w/ `Resolv`, these resolutions no longer happen automatically.

If I can find a link to the respective man page on macOS about this functionality, I can post that here for review from anyone who doesn't have access to macOS.