### PR TITLE
mark ClassHash as shareable, after all classes have been defined

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2339,6 +2339,8 @@ class Resolv
             return self.new(priority, weight, port, target)
           end
         end
+
+        Ractor.make_shareable(ClassHash) if defined?(Ractor)
       end
     end
   end


### PR DESCRIPTION
So that Resource classes are usable within ractors.

There's still this function to account for, for which I didn't get the use case. Legitimate to ignore, or worth working around?