### PR TITLE
Do not compress domain name in SRV RDATA

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1487,14 +1487,14 @@ class Resolv
           }
         end
 
-        def put_name(d)
-          put_labels(d.to_a)
+        def put_name(d, compress: true)
+          put_labels(d.to_a, compress: compress)
         end
 
-        def put_labels(d)
+        def put_labels(d, compress: true)
           d.each_index {|i|
             domain = d[i..-1]
-            if idx = @names[domain]
+            if compress && idx = @names[domain]
               self.put_pack("n", 0xc000 | idx)
               return
             else
@@ -2328,7 +2328,7 @@ class Resolv
             msg.put_pack("n", @priority)
             msg.put_pack("n", @weight)
             msg.put_pack("n", @port)
-            msg.put_name(@target)
+            msg.put_name(@target, compress: false)
           end
 
           def self.decode_rdata(msg) # :nodoc:

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -23,4 +23,12 @@ class TestResolvResource < Test::Unit::TestCase
   def test_coord
     Resolv::LOC::Coord.create('1 2 1.1 N')
   end
+
+  def test_srv_no_compress
+    # Domain name in SRV RDATA should not be compressed
+    issue29 = 'https://github.com/ruby/resolv/issues/29'
+    m = Resolv::DNS::Message.new(0)
+    m.add_answer('example.com', 0, Resolv::DNS::Resource::IN::SRV.new(0, 0, 0, 'www.example.com'))
+    assert_equal "\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x07example\x03com\x00\x00\x21\x00\x01\x00\x00\x00\x00\x00\x17\x00\x00\x00\x00\x00\x00\x03www\x07example\x03com\x00", m.encode, issue29
+  end
 end


### PR DESCRIPTION
[RFC2782] prohibits use of name compression for the target host name in the RDATA of a SRV record.

[RFC2782]: https://datatracker.ietf.org/doc/rfc2782/

Closes: https://github.com/ruby/resolv/issues/29