### PR TITLE
Prefer `Array#concat` over `#+=` on `Array`

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -198,7 +198,7 @@ class Resolv
               next unless addr
               @addr2name[addr] = [] unless @addr2name.include? addr
               @addr2name[addr] << hostname
-              @addr2name[addr] += aliases
+              @addr2name[addr].concat(aliases)
               @name2addr[hostname] = [] unless @name2addr.include? hostname
               @name2addr[hostname] << addr
               aliases.each {|n|
@@ -967,7 +967,7 @@ class Resolv
             next unless keyword
             case keyword
             when 'nameserver'
-              nameserver += args
+              nameserver.concat(args)
             when 'domain'
               next if args.empty?
               search = [args[0]]


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/19621