### PR TITLE
Catch EPROTONOSUPPORT as a sign of no IPv6 as well

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -750,7 +750,7 @@ class Resolv
               next if @socks_hash[bind_host]
               begin
                 sock = UDPSocket.new(af)
-              rescue Errno::EAFNOSUPPORT
+              rescue Errno::EAFNOSUPPORT, Errno::EPROTONOSUPPORT
                 next # The kernel doesn't support the address family.
               end
               @socks << sock


### PR DESCRIPTION
If IPv6 is disabled inside a freebsd jail, it seems this returns EPROTONOSUPPORT and not EAFNOSUPPORT. In both cases, we should simply try some other listed DNS servers.

Fixes #19928 (https://bugs.ruby-lang.org/issues/19928)