### PR TITLE
Allow setting default Resolv::DNS config in Resolv.new

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -83,9 +83,22 @@ class Resolv
 
   ##
   # Creates a new Resolv using +resolvers+.
+  #
+  # If +resolvers+ is not given, a hash, or +nil+, uses a Hosts resolver and
+  # and a DNS resolver.  If +resolvers+ is a hash, uses the hash as
+  # configuration for the DNS resolver.
 
-  def initialize(resolvers=nil, use_ipv6: nil)
-    @resolvers = resolvers || [Hosts.new, DNS.new(DNS::Config.default_config_hash.merge(use_ipv6: use_ipv6))]
+  def initialize(resolvers=(arg_not_set = true; nil), use_ipv6: (keyword_not_set = true; nil))
+    if !keyword_not_set && !arg_not_set
+      warn "Support for separate use_ipv6 keyword is deprecated, as it is ignored if an argument is provided. Do not provide a positional argument if using the use_ipv6 keyword argument.", uplevel: 1
+    end
+
+    @resolvers = case resolvers
+    when Hash, nil
+      [Hosts.new, DNS.new(DNS::Config.default_config_hash.merge(resolvers || {}))]
+    else
+      resolvers
+    end
   end
 
   ##


### PR DESCRIPTION
Instead of just passing the use_ipv6 option, pass all options given. By using a singular hash argument instead of keywords, this avoids the issue when a user does:

```ruby
Resolv.new([Resolv::DNS.new], use_ipv6: false)
```

Which would have resulted in the use_ipv6 option being ignored.

This is backwards compatible, because there has not yet been a release with the use_ipv6 keyword supported.

Prompted by https://github.com/ruby/resolv/pull/14#issuecomment-1825944745