### PR TITLE
ci: Exclude Ruby 2.5 on macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
         include:
           - ruby: mswin
             os: windows-latest
+        exclude:
+          - ruby: 2.5
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Because Ruby 2.5 isn't available on macos-14 (the current macos-latest).