### PR TITLE
Securerandom should be always available

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3,11 +3,7 @@
 require 'socket'
 require 'timeout'
 require 'io/wait'
-
-begin
-  require 'securerandom'
-rescue LoadError
-end
+require 'securerandom'
 
 # Resolv is a thread-aware DNS resolver library written in Ruby.  Resolv can
 # handle multiple DNS requests concurrently without blocking the entire Ruby
@@ -613,16 +609,10 @@ class Resolv
       }
     end
 
-    if defined? SecureRandom
-      def self.random(arg) # :nodoc:
-        begin
-          SecureRandom.random_number(arg)
-        rescue NotImplementedError
-          rand(arg)
-        end
-      end
-    else
-      def self.random(arg) # :nodoc:
+    def self.random(arg) # :nodoc:
+      begin
+        SecureRandom.random_number(arg)
+      rescue NotImplementedError
         rand(arg)
       end
     end


### PR DESCRIPTION
Securerandom has been there since [2007](https://github.com/ruby/ruby/commit/52ec7cc543605ccb43e883c2a89f4a90e8cb67c9).

The commit that started rescuing the `LoadError` was introduced in [2008](https://github.com/ruby/ruby/commit/2577fa6dccd454fe92009b306af212e7e73bf906), so I believe the fallback code has never been used?