### PR TITLE
Ractor compat

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -2125,7 +2125,14 @@ class Resolv
 
       attr_reader :ttl
 
-      ClassHash = {} # :nodoc:
+      ClassHash = Module.new do
+        module_function
+
+        def []=(type_class_value, klass)
+          type_value, class_value = type_class_value
+          Resource.const_set(:"Type#{type_value}_Class#{class_value}", klass)
+        end
+      end
 
       def encode_rdata(msg) # :nodoc:
         raise NotImplementedError.new
@@ -2163,7 +2170,9 @@ class Resolv
       end
 
       def self.get_class(type_value, class_value) # :nodoc:
-        return ClassHash[[type_value, class_value]] ||
+        cache = :"Type#{type_value}_Class#{class_value}"
+
+        return (const_defined?(cache) && const_get(cache)) ||
                Generic.create(type_value, class_value)
       end
 


### PR DESCRIPTION
The PR refactores `ClassHash` approach to be ractor-safe while keeping backwards compatibility. It also freezes the content of default_config_hash, which should not be mutable anyway (and this also makes it shareable across ractors).