### PR TITLE
Omit Windows and MinGW platforms with with_udp_and_tcp

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -83,6 +83,8 @@ class TestResolvDNS < Test::Unit::TestCase
           # See: https://stackoverflow.com/questions/48478869/cannot-bind-to-some-ports-due-to-permission-denied
           retries_remaining -= 1
           retry if retries_remaining > 0
+          # Windows and MinGW CI can't bind to the same port with ten retries.
+          omit if /mswin|mingw/ =~ RUBY_PLATFORM
           raise
         end
 


### PR DESCRIPTION
https://github.com/ruby/resolv/actions/runs/12021339854/job/33511655994?pr=64

```
  => 705:     with_udp_and_tcp('127.0.0.1', 0) do |u1, t1|
     706:       with_udp_and_tcp('127.0.0.1', 0) do |u2,t2|
     707:         u2.close # XXX: u2 UDP socket is not used, but using #with_udp_and_tcp to enable Windows EACCES workaround
     708:         _, server1_port, _, server1_address = u1.addr
Error: Errno::EACCES: Permission denied - bind(2) for "127.0.0.1" port 55685
```

https://github.com/ruby/ruby/actions/runs/12005069051/job/33461068529?pr=12161

```
    1) Error:
  TestResolvDNS#test_multiple_servers_with_timeout_and_truncated_tcp_fallback:
  Errno::EACCES: Permission denied - bind(2) for "127.0.0.1" port 50676
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer#initialize'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer.new'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TestResolvDNS#with_udp_and_tcp'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:705:in 'TestResolvDNS#test_multiple_servers_with_timeout_and_truncated_tcp_fallback'
```