### PR TITLE
Integrate JRuby changes

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -160,11 +160,14 @@ class Resolv
 
   class ResolvTimeout < Timeout::Error; end
 
+  WINDOWS = /mswin|cygwin|mingw|bccwin/ =~ RUBY_PLATFORM || ::RbConfig::CONFIG['host_os'] =~ /mswin/
+  private_constant :WINDOWS
+
   ##
   # Resolv::Hosts is a hostname resolver that uses the system hosts file.
 
   class Hosts
-    if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM and
+    if WINDOWS
       begin
         require 'win32/resolv'
         DefaultFileName = Win32::Resolv.get_hosts_path || IO::NULL
@@ -994,7 +997,7 @@ class Resolv
         if File.exist? filename
           config_hash = Config.parse_resolv_conf(filename)
         else
-          if /mswin|cygwin|mingw|bccwin/ =~ RUBY_PLATFORM
+          if WINDOWS
             require 'win32/resolv'
             search, nameserver = Win32::Resolv.get_resolv_info
             config_hash = {}


### PR DESCRIPTION
There are only a few diffs to resolve in the JRuby version, other than being a bit behind:

* [x] Windows check cannot use RUBY_PLATFORM on JRuby, so it uses RbConfig as well now.
* [ ] Using IPAddr for comparing addresses. I'm not sure if this is necessary anymore (tests pass without it, but unsure how well this is tested). See https://github.com/jruby/jruby/pull/4496.
* [ ] A leak fix that does not seem to have been ported to ruby/resolve, but the leak may have been fixed in another way. See https://github.com/jruby/jruby/pull/5722.
* [ ] A leak fix that does seem to have been ported, since the `lazy_initialize` logic exists in both versions. See https://github.com/jruby/jruby/pull/5524.

With only the Windows check fixed, tests pass on JRuby (double-confirmed by replacing JRuby's local copy with the edited version from this repo). I need some assistance from other maintainers as to whether these three PRs need to be ported over. cc @hsbt @nobu 

Fixes #19. Once merged and released, JRuby can start shipping resolv as a default gem, rather than a non-gem stdlib.