### PR TITLE
win32/resolv: add headers to GetNetworkParams check.

### DIFF
--- a/ext/win32/resolv/extconf.rb
+++ b/ext/win32/resolv/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-if RUBY_ENGINE == "ruby" and have_library('iphlpapi', 'GetNetworkParams')
+if RUBY_ENGINE == "ruby" and have_library('iphlpapi', 'GetNetworkParams', ['windows.h', 'iphlpapi.h'])
   create_makefile('win32/resolv')
 else
   File.write('Makefile', "all clean install:\n\t@echo Done: $(@)\n")


### PR DESCRIPTION
On 32-bit Cygwin at least, it was failing to find that function, presumably due to it being stdcall.

32-bit Cygwin is not supported anymore by the Cygwin folks, but this seems a correct change in general.

See ruby/ruby#12645