### PR TITLE
Load win32/resolv with rake test

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -182,7 +182,7 @@ class Resolv
   class Hosts
     if WINDOWS
       begin
-        require 'win32/resolv'
+        require 'win32/resolv' unless defined?(Win32::Resolv)
         DefaultFileName = Win32::Resolv.get_hosts_path || IO::NULL
       rescue LoadError
       end
@@ -1023,7 +1023,7 @@ class Resolv
           config_hash = Config.parse_resolv_conf(filename)
         else
           if WINDOWS
-            require 'win32/resolv'
+            require 'win32/resolv' unless defined?(Win32::Resolv)
             search, nameserver = Win32::Resolv.get_resolv_info
             config_hash = {}
             config_hash[:nameserver] = nameserver if nameserver

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -1,4 +1,10 @@
 require "test/unit"
 require "core_assertions"
 
+if RUBY_PLATFORM =~ /mswin|mingw/
+  # "win32/resolv" is installation path by Ruby installer.
+  # We should load that file manually for testing with Windows platform.
+  require_relative "../../ext/win32/resolv/lib/resolv"
+end
+
 Test::Unit::TestCase.include Test::Unit::CoreAssertions


### PR DESCRIPTION
"win32/resolv" is installation path by Ruby installer. So, the current test suite didn't load `ext/win32/resolv/lib/resolv`.

We should load that file manually for testing with Windows platform.