### PR TITLE
win32/resolv: fix loading of `NV Domain`

### DIFF
--- a/ext/win32/resolv/lib/resolv.rb
+++ b/ext/win32/resolv/lib/resolv.rb
@@ -82,7 +82,7 @@ module Win32
           nvdom = get_item_property(TCPIP_NT, 'NV Domain')
 
           unless nvdom.empty?
-            @search = [ nvdom ]
+            search = [ nvdom ]
             udmnd = get_item_property(TCPIP_NT, 'UseDomainNameDevolution').to_i
             if udmnd != 0
               if /^\w+\./ =~ nvdom


### PR DESCRIPTION
When resolving names using only the host name,
Fixed a bug where the primary domain suffix was not retrieved and the service failed.