### PR TITLE
quote registry value name 'NV Domain' properly

### DIFF
--- a/ext/win32/resolv/lib/resolv.rb
+++ b/ext/win32/resolv/lib/resolv.rb
@@ -134,7 +134,7 @@ module Win32
             ""
           end
         else
-          cmd = "Get-ItemProperty -Path 'HKLM:\\#{path}' -Name '#{name}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty #{name}"
+          cmd = "Get-ItemProperty -Path 'HKLM:\\#{path}' -Name '#{name}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty '#{name}'"
           output, _ = Open3.capture2('powershell', '-Command', cmd)
           output.strip
         end


### PR DESCRIPTION
I met an error below:
```
C:\git\resolv>bundle exec rake test
make
make: Nothing to be done for 'all'.
C:/Ruby35-x64/lib/ruby/3.5.0+0/win32/registry.rb:2: warning: fiddle/import is found in fiddle, which is not part of the default gems since Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to fix this error.
C:/git/resolv/ext/win32/resolv/lib/resolv.rb:139:in 'String#strip': invalid byte sequence in UTF-8 (Encoding::CompatibilityError)
        from C:/git/resolv/ext/win32/resolv/lib/resolv.rb:139:in 'Win32::Resolv.get_item_property'
        from C:/git/resolv/ext/win32/resolv/lib/resolv.rb:82:in 'Win32::Resolv.get_info'
        from C:/git/resolv/ext/win32/resolv/lib/resolv.rb:16:in 'Win32::Resolv.get_resolv_info'
        from C:/git/resolv/lib/resolv.rb:1026:in 'Resolv::DNS::Config.default_config_hash'
        from C:/git/resolv/lib/resolv.rb:94:in 'Resolv#initialize'
        from C:/git/resolv/lib/resolv.rb:3464:in 'Class#new'
        from C:/git/resolv/lib/resolv.rb:3464:in '<class:Resolv>'
        from C:/git/resolv/lib/resolv.rb:34:in '<top (required)>'
        from C:/Ruby35-x64/lib/ruby/3.5.0+0/bundled_gems.rb:59:in 'Kernel.require'
        from C:/Ruby35-x64/lib/ruby/3.5.0+0/bundled_gems.rb:59:in 'block (2 levels) in Kernel#replace_require'
        from C:/git/resolv/test/resolv/test_addr.rb:3:in '<top (required)>'
        from C:/Ruby35-x64/lib/ruby/3.5.0+0/bundled_gems.rb:59:in 'Kernel.require'
        from C:/Ruby35-x64/lib/ruby/3.5.0+0/bundled_gems.rb:59:in 'block (2 levels) in Kernel#replace_require'
        from C:/Ruby35-x64/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in 'block in <main>'
        from C:/Ruby35-x64/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in 'Array#select'
        from C:/Ruby35-x64/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in '<main>'
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)

C:\git\resolv>
```
This indicates Encoding::CompatibilityError but root cause is invalid syntax on powershell commandline, alternative method used if fiddle gem is unavailable.
It also occurred during my ``make main`` build of ruby-head. 

An error message is reproduced as:
```
C:\git\resolv>powershell -Command "Get-ItemProperty -Path 'HKLM:SYSTEM\CurrentControlSet\Services\Tcpip\Parameters' -Name 'NV Domain' | Select-Object -ExpandProperty NV Domain"
Select-Object : プロパティ "NV" が見つかりません。
発生場所 行:1 文字:102
+ ... rameters' -Name 'NV Domain' | Select-Object -ExpandProperty NV Domain
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (@{NV Domain=mag....Core\Registry}:PSObject) [Select-Object]、PSArgumentException
    + FullyQualifiedErrorId : ExpandPropertyNotFound,Microsoft.PowerShell.Commands.SelectObjectCommand
```
note: powershell.exe outputs CP932, ruby's external encoding is UTF-8 by default.

This error will only occur if the NV Domain setting is present and the console code page setting makes the powershell error message incorrect as UTF-8.

There are possible ways to make it more robust, such as forcing powershell to output in UTF-8 and checking its exit code, but  just fixing the obvious bugs here.