### PR TITLE
Require rbconfig in resolv.rb

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -4,6 +4,7 @@ require 'socket'
 require 'timeout'
 require 'io/wait'
 require 'securerandom'
+require 'rbconfig'
 
 # Resolv is a thread-aware DNS resolver library written in Ruby.  Resolv can
 # handle multiple DNS requests concurrently without blocking the entire Ruby


### PR DESCRIPTION
Uses ::RbConfig::CONFIG['host_os']

Found with ruby --disable-gems -e '...'
