### PR TITLE
Fix invalid "Broken registry" warning for UseDomainNameDevolution

### DIFF
--- a/ext/win32/resolv/lib/resolv.rb
+++ b/ext/win32/resolv/lib/resolv.rb
@@ -83,7 +83,7 @@ module Win32
 
           unless nvdom.empty?
             @search = [ nvdom ]
-            udmnd = get_item_property(TCPIP_NT, 'UseDomainNameDevolution').to_i
+            udmnd = get_item_property(TCPIP_NT, 'UseDomainNameDevolution', dword: true)
             if udmnd != 0
               if /^\w+\./ =~ nvdom
                 devo = $'
@@ -126,17 +126,21 @@ module Win32
         [ search.uniq, nameserver.uniq ]
       end
 
-      def get_item_property(path, name, expand: false)
+      def get_item_property(path, name, expand: false, dword: false)
         if defined?(Win32::Registry)
           Registry::HKEY_LOCAL_MACHINE.open(path) do |reg|
-            expand ? reg.read_s_expand(name) : reg.read_s(name)
+            if dword
+              reg.read_i(name)
+            else
+              expand ? reg.read_s_expand(name) : reg.read_s(name)
+            end
           rescue Registry::Error
-            ""
+            dword ? 0 : ""
           end
         else
           cmd = "Get-ItemProperty -Path 'HKLM:\\#{path}' -Name '#{name}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty '#{name}'"
           output, _ = Open3.capture2('powershell', '-Command', cmd)
-          output.strip
+          dword ? output.strip.to_i : output.strip
         end
       end
     end


### PR DESCRIPTION
This value is dword, not a string.

Amends 720e25034042e0fa964f849bc19b4acb315d580e.