### PR TITLE
Increase DNS resolver timeouts in truncated TCP fallback test

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -721,8 +721,8 @@ class TestResolvDNS < Test::Unit::TestCase
 
         client_thread = Thread.new do
           Resolv::DNS.open(nameserver_port: [[server1_address, server1_port], [server2_address, server2_port]]) do |dns|
-            dns.timeouts = [EnvUtil.apply_timeout_scale(0.1),
-                            EnvUtil.apply_timeout_scale(0.2)]
+            dns.timeouts = [EnvUtil.apply_timeout_scale(0.5),
+                            EnvUtil.apply_timeout_scale(1)]
             dns.getresources('foo.example.org', Resolv::DNS::Resource::IN::A)
           end
         end


### PR DESCRIPTION
- Increase resolver timeouts from 0.1s/0.2s to 0.5s/1s in `test_multiple_servers_with_timeout_and_truncated_tcp_fallback`
- The test intentionally hangs TCP server1 to trigger fallback to server2, but the previous timeouts were too tight for loaded CI machines (observed as a timeout flake in YJIT CI)