### PR TITLE
Resolv::LOC fixes

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3428,7 +3428,10 @@ class Resolv
 
       # Regular expression LOC Alt must match.
 
-      Regex = /^([+-]*\d+\.*\d*)[m]$/
+      Regex = /\A([+-]?0*\d{1,8}(?:\.\d+)?)m\z/
+
+      # Bias to a base of 100,000m below the WGS 84 reference spheroid.
+      Bias = 100_000_00
 
       ##
       # Creates a new LOC::Alt from +arg+ which may be:
@@ -3444,8 +3447,11 @@ class Resolv
           unless Regex =~ arg
             raise ArgumentError.new("not a properly formed Alt string: " + arg)
           end
-          altitude = [($1.to_f*(1e2))+(1e7)].pack("N")
-          return Alt.new(altitude)
+          altitude = ($1.to_f * 100).to_i + Bias
+          unless (0...0x1_0000_0000) === altitude
+            raise ArgumentError.new("out of raise as Alt: #{arg}")
+          end
+          return new([altitude].pack("N"))
         else
           raise ArgumentError.new("cannot interpret as Alt: #{arg.inspect}")
         end

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3344,10 +3344,9 @@ class Resolv
         when Coord
           return arg
         when String
-          unless Regex =~ arg && $1.to_f < 180
+          unless (m = Regex.match(arg)) && m[1].to_i < 180
             raise ArgumentError.new("not a properly formed Coord string: " + arg)
           end
-          m = $~
           hemi = (m[4][/[NE]/]) || (m[4][/[SW]/]) ? 1 : -1
           coordinates = [ ((m[1].to_i*(36e5)) + (m[2].to_i*(6e4)) +
                            (m[3].to_f*(1e3))) * hemi+(2**31) ].pack("N")

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3268,7 +3268,7 @@ class Resolv
 
       # Regular expression LOC size must match.
 
-      Regex = /^(\d+\.*\d*)[m]$/
+      Regex = /\A0*(\d{1,8}(?:\.\d+)?)m\z/
 
       ##
       # Creates a new LOC::Size from +arg+ which may be:
@@ -3284,8 +3284,11 @@ class Resolv
           unless Regex =~ arg
             raise ArgumentError.new("not a properly formed Size string: " + arg)
           end
-          scalar = [(($1.to_f*(1e2)).to_i.to_s[0].to_i*(2**4)+(($1.to_f*(1e2)).to_i.to_s.length-1))].pack("C")
-          return Size.new(scalar)
+          unless (0.0...1e8) === (scalar = $1.to_f)
+            raise ArgumentError.new("out of range as Size: #{arg}")
+          end
+          str = (scalar * 100).to_i.to_s
+          return new([(str[0].to_i << 4) + (str.bytesize-1)].pack("C"))
         else
           raise ArgumentError.new("cannot interpret as Size: #{arg.inspect}")
         end

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3281,12 +3281,10 @@ class Resolv
         when Size
           return arg
         when String
-          scalar = ''
-          if Regex =~ arg
-            scalar = [(($1.to_f*(1e2)).to_i.to_s[0].to_i*(2**4)+(($1.to_f*(1e2)).to_i.to_s.length-1))].pack("C")
-          else
+          unless Regex =~ arg
             raise ArgumentError.new("not a properly formed Size string: " + arg)
           end
+          scalar = [(($1.to_f*(1e2)).to_i.to_s[0].to_i*(2**4)+(($1.to_f*(1e2)).to_i.to_s.length-1))].pack("C")
           return Size.new(scalar)
         else
           raise ArgumentError.new("cannot interpret as Size: #{arg.inspect}")
@@ -3346,16 +3344,14 @@ class Resolv
         when Coord
           return arg
         when String
-          coordinates = ''
-          if Regex =~ arg && $1.to_f < 180
-            m = $~
-            hemi = (m[4][/[NE]/]) || (m[4][/[SW]/]) ? 1 : -1
-            coordinates = [ ((m[1].to_i*(36e5)) + (m[2].to_i*(6e4)) +
-                             (m[3].to_f*(1e3))) * hemi+(2**31) ].pack("N")
-            orientation = m[4][/[NS]/] ? 'lat' : 'lon'
-          else
+          unless Regex =~ arg && $1.to_f < 180
             raise ArgumentError.new("not a properly formed Coord string: " + arg)
           end
+          m = $~
+          hemi = (m[4][/[NE]/]) || (m[4][/[SW]/]) ? 1 : -1
+          coordinates = [ ((m[1].to_i*(36e5)) + (m[2].to_i*(6e4)) +
+                           (m[3].to_f*(1e3))) * hemi+(2**31) ].pack("N")
+          orientation = m[4][/[NS]/] ? 'lat' : 'lon'
           return Coord.new(coordinates,orientation)
         else
           raise ArgumentError.new("cannot interpret as Coord: #{arg.inspect}")
@@ -3440,12 +3436,10 @@ class Resolv
         when Alt
           return arg
         when String
-          altitude = ''
-          if Regex =~ arg
-            altitude = [($1.to_f*(1e2))+(1e7)].pack("N")
-          else
+          unless Regex =~ arg
             raise ArgumentError.new("not a properly formed Alt string: " + arg)
           end
+          altitude = [($1.to_f*(1e2))+(1e7)].pack("N")
           return Alt.new(altitude)
         else
           raise ArgumentError.new("cannot interpret as Alt: #{arg.inspect}")

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3305,8 +3305,8 @@ class Resolv
       attr_reader :scalar
 
       def to_s # :nodoc:
-        s = @scalar.unpack("H2").join.to_s
-        return ((s[0].to_i)*(10**(s[1].to_i-2))).to_s << "m"
+        s, = @scalar.unpack("C")
+        return "#{(s >> 4) * (10.0 ** ((s & 0xf) - 2))}m"
       end
 
       def inspect # :nodoc:

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3468,8 +3468,8 @@ class Resolv
       attr_reader :altitude
 
       def to_s # :nodoc:
-        a = @altitude.unpack("N").join.to_i
-        return ((a.to_f/1e2)-1e5).to_s + "m"
+        a, = @altitude.unpack("N")
+        return "#{(a - Bias).fdiv(100)}m"
       end
 
       def inspect # :nodoc:

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3331,7 +3331,10 @@ class Resolv
 
       # Regular expression LOC Coord must match.
 
-      Regex = /^(\d+)\s(\d+)\s(\d+\.\d+)\s([NESW])$/
+      Regex = /\A0*(\d{1,3})\s([0-5]?\d)\s([0-5]?\d(?:\.\d+)?)\s([NESW])\z/
+
+      # Bias for the equator/prime meridian, in thousandths of a second of arc.
+      Bias = 1 << 31
 
       ##
       # Creates a new LOC::Coord from +arg+ which may be:
@@ -3344,14 +3347,19 @@ class Resolv
         when Coord
           return arg
         when String
-          unless (m = Regex.match(arg)) && m[1].to_i < 180
+          unless m = Regex.match(arg)
             raise ArgumentError.new("not a properly formed Coord string: " + arg)
           end
 
-          dir = m[4]
-          hemi = dir[/[NE]/] ? 1 : -1
           arc = (m[1].to_i * 3_600_000) + (m[2].to_i * 60_000) + (m[3].to_f * 1_000).to_i
-          return Coord.new([arc * hemi + (2**31)].pack("N"), dir[/[NS]/] ? "lat" : "lon")
+          dir = m[4]
+          lat = dir[/[NS]/]
+          unless arc <= (lat ? 324_000_000 : 648_000_000) # (lat ? 90 : 180) * 3_600_000
+            raise ArgumentError.new("out of range as Coord: #{arg}")
+          end
+
+          hemi = dir[/[NE]/] ? 1 : -1
+          return new([arc * hemi + Bias].pack("N"), lat ? "lat" : "lon")
         else
           raise ArgumentError.new("cannot interpret as Coord: #{arg.inspect}")
         end
@@ -3359,10 +3367,10 @@ class Resolv
 
       # Internal use; use self.create.
       def initialize(coordinates,orientation)
-        unless coordinates.kind_of?(String)
+        unless coordinates.kind_of?(String) and coordinates.bytesize == 4
           raise ArgumentError.new("Coord must be a 32bit unsigned integer in hex format: #{coordinates.inspect}")
         end
-        unless orientation.kind_of?(String) && orientation[/^lon$|^lat$/]
+        unless orientation == "lon" || orientation == "lat"
           raise ArgumentError.new('Coord expects orientation to be a String argument of "lat" or "lon"')
         end
         @coordinates = coordinates

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3347,11 +3347,11 @@ class Resolv
           unless (m = Regex.match(arg)) && m[1].to_i < 180
             raise ArgumentError.new("not a properly formed Coord string: " + arg)
           end
-          hemi = (m[4][/[NE]/]) || (m[4][/[SW]/]) ? 1 : -1
-          coordinates = [ ((m[1].to_i*(36e5)) + (m[2].to_i*(6e4)) +
-                           (m[3].to_f*(1e3))) * hemi+(2**31) ].pack("N")
-          orientation = m[4][/[NS]/] ? 'lat' : 'lon'
-          return Coord.new(coordinates,orientation)
+
+          dir = m[4]
+          hemi = dir[/[NE]/] ? 1 : -1
+          arc = (m[1].to_i * 3_600_000) + (m[2].to_i * 60_000) + (m[3].to_f * 1_000).to_i
+          return Coord.new([arc * hemi + (2**31)].pack("N"), dir[/[NS]/] ? "lat" : "lon")
         else
           raise ArgumentError.new("cannot interpret as Coord: #{arg.inspect}")
         end

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -3387,22 +3387,17 @@ class Resolv
       attr_reader :orientation
 
       def to_s # :nodoc:
-          c = @coordinates.unpack("N").join.to_i
-          val      = (c - (2**31)).abs
-          fracsecs = (val % 1e3).to_i.to_s
-          val      = val / 1e3
-          secs     = (val % 60).to_i.to_s
-          val      = val / 60
-          mins     = (val % 60).to_i.to_s
-          degs     = (val / 60).to_i.to_s
-          posi = (c >= 2**31)
-          case posi
-          when true
-            hemi = @orientation[/^lat$/] ? "N" : "E"
+          c, = @coordinates.unpack("N")
+          val = (c -= Bias).abs
+          val, fracsecs = val.divmod(1000)
+          val, secs     = val.divmod(60)
+          degs, mins    = val.divmod(60)
+          hemi = if c.negative?
+            @orientation == "lon" ? "W" : "S"
           else
-            hemi = @orientation[/^lon$/] ? "W" : "S"
+            @orientation == "lat" ? "N" : "E"
           end
-          return degs << " " << mins << " " << secs << "." << fracsecs << " " << hemi
+          format("%d %02d %02d.%03d %s", degs, mins, secs, fracsecs, hemi)
       end
 
       def inspect # :nodoc:

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -55,6 +55,7 @@ class TestResolvResourceLOC < Test::Unit::TestCase
 
     assert_equal(orientation, coord.orientation)
     assert_equal([coordinate].pack("N"), coord.coordinates)
+    assert_equal(coord, Resolv::LOC::Coord.create(coord.to_s))
   end
 end
 

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -20,16 +20,37 @@ class TestResolvResource < Test::Unit::TestCase
     assert_equal(@name1.hash, @name2.hash, bug10857)
   end
 
-  def test_coord
-    Resolv::LOC::Coord.create('1 2 1.1 N')
-  end
-
   def test_srv_no_compress
     # Domain name in SRV RDATA should not be compressed
     issue29 = 'https://github.com/ruby/resolv/issues/29'
     m = Resolv::DNS::Message.new(0)
     m.add_answer('example.com', 0, Resolv::DNS::Resource::IN::SRV.new(0, 0, 0, 'www.example.com'))
     assert_equal "\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x07example\x03com\x00\x00\x21\x00\x01\x00\x00\x00\x00\x00\x17\x00\x00\x00\x00\x00\x00\x03www\x07example\x03com\x00", m.encode, issue29
+  end
+end
+
+class TestResolvResourceLOC < Test::Unit::TestCase
+  def test_coord
+    assert_coord('1 2 1.1 N', 'lat', 0x8038c78c)
+    assert_coord('42 21 43.952 N', 'lat', 0x89170690)
+    assert_coord('71 5 6.344 W', 'lon', 0x70bf2dd8)
+    assert_coord('52 14 05.000 N', 'lat', 0x8b3556c8)
+    assert_coord('90 0 0.000 N', 'lat', 0x934fd900)
+    assert_coord('90 0 0.000 S', 'lat', 0x6cb02700)
+    assert_coord('00 8 50.000 E', 'lon', 0x80081650)
+    assert_coord('0 8 50.001 E', 'lon', 0x80081651)
+    assert_coord('32 07 19.000 S', 'lat', 0x791b7d28)
+    assert_coord('116 02 25.000 E', 'lon', 0x98e64868)
+    assert_coord('116 02 25.000 W', 'lon', 0x6719b798)
+    assert_raise(ArgumentError) {Resolv::LOC::Coord.create('180 0 0.001 E')}
+    assert_raise(ArgumentError) {Resolv::LOC::Coord.create('180 0 0.001 W')}
+  end
+
+  private def assert_coord(input, orientation, coordinate)
+    coord = Resolv::LOC::Coord.create(input)
+
+    assert_equal(orientation, coord.orientation)
+    assert_equal([coordinate].pack("N"), coord.coordinates)
   end
 end
 

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -42,6 +42,10 @@ class TestResolvResourceLOC < Test::Unit::TestCase
     assert_coord('32 07 19.000 S', 'lat', 0x791b7d28)
     assert_coord('116 02 25.000 E', 'lon', 0x98e64868)
     assert_coord('116 02 25.000 W', 'lon', 0x6719b798)
+    assert_coord('180 00 00.000 E', 'lon', 0xa69fb200)
+    assert_coord('180 00 00.000 W', 'lon', 0x59604e00)
+    assert_raise(ArgumentError) {Resolv::LOC::Coord.create('90 0 0.001 N')}
+    assert_raise(ArgumentError) {Resolv::LOC::Coord.create('90 0 0.001 S')}
     assert_raise(ArgumentError) {Resolv::LOC::Coord.create('180 0 0.001 E')}
     assert_raise(ArgumentError) {Resolv::LOC::Coord.create('180 0 0.001 W')}
   end

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -75,6 +75,27 @@ class TestResolvResourceLOC < Test::Unit::TestCase
     assert_equal([coordinate].pack("N"), coord.coordinates)
     assert_equal(coord, Resolv::LOC::Coord.create(coord.to_s))
   end
+
+  def test_alt
+    assert_alt("0.0m", 0)
+    assert_alt("+0.0m", 0)
+    assert_alt("-0.0m", 0)
+    assert_alt("+0.01m", 1)
+    assert_alt("1.0m", 100)
+    assert_alt("+1.0m", 100)
+    assert_alt("100000.0m", +10000000)
+    assert_alt("+100000.0m", +10000000)
+    assert_alt("-100000.0m", -10000000)
+    assert_alt("+42849672.95m", 0xffff_ffff-100_000_00)
+    assert_raise(ArgumentError) {Resolv::LOC::Alt.create("-100000.01m")}
+    assert_raise(ArgumentError) {Resolv::LOC::Alt.create("+42849672.96m")}
+  end
+
+  private def assert_alt(input, altitude)
+    alt = Resolv::LOC::Alt.create(input)
+
+    assert_equal([altitude + 1e7].pack("N"), alt.altitude)
+  end
 end
 
 class TestResolvResourceCAA < Test::Unit::TestCase

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -95,6 +95,7 @@ class TestResolvResourceLOC < Test::Unit::TestCase
     alt = Resolv::LOC::Alt.create(input)
 
     assert_equal([altitude + 1e7].pack("N"), alt.altitude)
+    assert_equal(alt, Resolv::LOC::Alt.create(alt.to_s))
   end
 end
 

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -30,6 +30,23 @@ class TestResolvResource < Test::Unit::TestCase
 end
 
 class TestResolvResourceLOC < Test::Unit::TestCase
+  def test_size_create
+    assert_size("0.0m", 0, 0)
+    assert_size("0.01m", 1, 0)
+    assert_size("0.09m", 9, 0)
+    assert_size("0.11m", 1, 1)
+    assert_size("1.0m", 1, 2)
+    assert_size("1234.56m", 1, 5)
+    assert_size("12345678.90m", 1, 9)
+    assert_size("98765432.10m", 9, 9)
+    assert_raise(ArgumentError) {Resolv::LOC::Size.create("100000000.00m")}
+  end
+
+  private def assert_size(input, base, power)
+    size = Resolv::LOC::Size.create(input)
+    assert_equal([(base << 4) + power], size.scalar.unpack("C"))
+  end
+
   def test_coord
     assert_coord('1 2 1.1 N', 'lat', 0x8038c78c)
     assert_coord('42 21 43.952 N', 'lat', 0x89170690)

--- a/test/resolv/test_resource.rb
+++ b/test/resolv/test_resource.rb
@@ -45,6 +45,7 @@ class TestResolvResourceLOC < Test::Unit::TestCase
   private def assert_size(input, base, power)
     size = Resolv::LOC::Size.create(input)
     assert_equal([(base << 4) + power], size.scalar.unpack("C"))
+    assert_equal(size, Resolv::LOC::Size.create(size.to_s))
   end
 
   def test_coord


### PR DESCRIPTION
These classes have several bugs, but no tests ever.

- In `Coord.create`, hemispheres condition is obviously wrong, always true,  and south/west coordinates encoded as north/east hemisphere.
- In `Coord#to_s`, leading zeros in sub second part is suppressed wrongly. `0.01` and `0.1` are different.
- In `Size#to_s`, `Size` smaller than 1m was represented as rational.
- In `create` methods, no range checks or not enough.