### PR TITLE
Omit the macOS 26.1+ DNS timeout, and exclude Ruby 2.5 on macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest ]
+        exclude:
+          - ruby: 2.5
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -487,6 +487,8 @@ class TestResolvDNS < Test::Unit::TestCase
       if RUBY_PLATFORM.match?(/mingw/)
         # cannot repo locally
         omit 'Timeout Error on MinGW CI'
+      elsif macos?([26,1]..[])
+        omit 'Timeout Error on macOS 26.1+'
       else
         raise Timeout::Error
       end


### PR DESCRIPTION
`master` omits `test_no_server` when the host runs macOS 26.1 or later, but the 0.3 branch never got that change. Backporting a 0.3.x release into `ruby/ruby` replaces `test/resolv/test_dns.rb` wholesale, so the omission had to be restored by hand every time. This adds the same branch here.

The condition is `macos?([26,1]..[])` rather than `macos?(26,1)`, matching what `master` ended up with. The `macos?` helper in `test-unit-ruby-core` compares an exact version unless it is given a `Range`, and the `..[]` form keeps the file parsable on Ruby 2.5, which this branch still tests.

The second commit is a cherry-pick of c5eefe9ca0, which `master` and `v0-7` already carry. `ruby/setup-ruby` cannot install CRuby 2.5 on the arm64 `macos-latest` image, so that job fails before any test runs and its `fail-fast` cancels every other macOS job. This branch has been red for that reason alone.
